### PR TITLE
Move paths setting to correct part of svelte config

### DIFF
--- a/patterns/svelte.config.js
+++ b/patterns/svelte.config.js
@@ -6,9 +6,10 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter(),
+		paths: {base: process.env.URL_PREFIX || ""},
 	},
-	paths: {base: '/patterns'},
+	
 };
 
 export default config;


### PR DESCRIPTION
To test locally, run the app with `URL_PREFIX=/patterns npm run dev` - the app should now be served under the `/patterns` prefix

To deploy it with this, just create a `URL_PREFIX` environment variable with the appropriate path (starting with /)